### PR TITLE
Fix password visibility icon logic

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -40,7 +40,7 @@ export default function LoginPage() {
             className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500"
             aria-label={showPassword ? 'Ocultar senha' : 'Mostrar senha'}
           >
-            {showPassword ? <VisibilityOff fontSize="small" /> : <Visibility fontSize="small" />}
+            {showPassword ? <Visibility fontSize="small" /> : <VisibilityOff fontSize="small" />}
           </button>
         </div>
 


### PR DESCRIPTION
## Summary
- correct the visibility icon toggle on the login page

## Testing
- `npm run lint` *(fails: `next` not found due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6875352163fc83308ad7448097b3fb4b