### PR TITLE
Update placeholder color

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,13 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+input,
+textarea {
+  color: #777777;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: #777777;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -24,7 +24,7 @@ export default function LoginPage() {
           id="email"
           type="email"
           placeholder="Email"
-          className="w-full px-4 py-3 rounded-lg bg-white text-sm placeholder-gray-400 shadow outline-none
+          className="w-full px-4 py-3 rounded-lg bg-white text-sm text-[#777777] placeholder-[#777777] shadow outline-none
                      border border-transparent
                      hover:border-[#F1D6A7]
                      focus:ring-2 focus:ring-[#F1D6A7]"
@@ -37,7 +37,7 @@ export default function LoginPage() {
             id="password"
             type={showPassword ? 'text' : 'password'}
             placeholder="Senha"
-            className="w-full px-4 py-3 rounded-lg bg-white text-sm placeholder-gray-400 shadow outline-none
+            className="w-full px-4 py-3 rounded-lg bg-white text-sm text-[#777777] placeholder-[#777777] shadow outline-none
                        border border-transparent
                        hover:border-[#F1D6A7]
                        focus:ring-2 focus:ring-[#F1D6A7]"


### PR DESCRIPTION
## Summary
- use consistent input text & placeholder color in login page
- add global styles for inputs

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764bf03f78833093a3eaea4d01423c