### PR TITLE
Atualiza listagens de profissionais e produtos

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,3 +34,19 @@ input::placeholder,
 textarea::placeholder {
   color: #777777;
 }
+
+/* Oculta as barras de navegação dos containers com scroll */
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+/* Remove o “N” preto do rodapé exibido pelo Next.js em desenvolvimento */
+#nextjs__container,
+#__next-build-watcher {
+  display: none !important;
+}

--- a/src/app/professionals/page.tsx
+++ b/src/app/professionals/page.tsx
@@ -2,10 +2,50 @@
 
 import Image from 'next/image';
 import { useState } from 'react';
-import { Search, ArrowForwardIos, Home, Build, SearchOutlined, ContentCut, Person } from '@mui/icons-material';
+import {
+  Search,
+  ArrowForwardIos,
+  Home,
+  Build,
+  SearchOutlined,
+  ContentCut,
+  Person,
+} from '@mui/icons-material';
 
 export default function ProfessionalsPage() {
   const [search, setSearch] = useState('');
+
+  const works = [
+    'icon_cleaner.png',
+    'icon_electrician.png',
+    'icon_furniture.png',
+    'icon_gardener.png',
+    'icon_glazier.png',
+    'icon_gram.png',
+    'icon_mason.png',
+    'icon_masseuse.png',
+    'icon_painter.png',
+    'icon_pet_sitter.png',
+    'icon_plumber.png',
+    'icon_pool.png',
+    'icon_repairs.png',
+  ];
+
+  const storeItems = [
+    'abajur.jpg',
+    'almofada.webp',
+    'arranjo.jpg',
+    'calefator.webp',
+    'cessto.jpg',
+    'comoda.jpg',
+    'espelho.jpg',
+    'pillow.png',
+    'quadro.jpg',
+    'sofa.jpg',
+    'talher.jpg',
+    'taça.png',
+    'vaso.jpg',
+  ];
 
   return (
     <div className="min-h-screen bg-[#FDFDFB] px-4 py-6 flex flex-col space-y-6 pb-20">
@@ -35,14 +75,23 @@ export default function ProfessionalsPage() {
       {/* Seção 3: lista horizontal de profissionais */}
       <div className="overflow-x-auto px-4 pb-2 cursor-grab no-scrollbar">
         <div className="flex space-x-5">
-          {Array.from({ length: 13 }).map((_, i) => (
-            <div key={i} className="flex flex-col items-center">
-              <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center mb-1">
-                <Image src="/icon_cleaner.png" alt="Cleaner" width={24} height={24} />
+          {works.map((file) => {
+            const name = file
+              .replace('icon_', '')
+              .replace(/\.[^/.]+$/, '')
+              .replace(/_/g, ' ');
+
+            return (
+              <div key={file} className="flex flex-col items-center">
+                <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center mb-1 overflow-hidden">
+                  <Image src={`/works/${file}`} alt={name} width={24} height={24} />
+                </div>
+                <span className="text-[9px] text-[#6D6D6D] font-medium font-inter capitalize">
+                  {name}
+                </span>
               </div>
-              <span className="text-[9px] text-[#6D6D6D] font-medium font-inter">Cleaner</span>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
 
@@ -67,16 +116,26 @@ export default function ProfessionalsPage() {
       <div className="px-4">
         <h2 className="text-[15px] font-medium text-[#484747] font-inter mb-2">Novidades</h2>
         <div className="flex space-x-4 overflow-x-auto cursor-grab no-scrollbar">
-          {Array.from({ length: 10 }).map((_, i) => (
-            <div key={i} className="w-28 flex-shrink-0 border rounded-xl p-2 text-center text-xs bg-white shadow">
-              <div className="mb-1 w-full h-14 rounded overflow-hidden">
-                <Image src="/store/taça.png" alt="Produto" width={122} height={56} className="object-cover w-full h-full" />
+          {storeItems.map((file) => {
+            const name = file.replace(/\.[^/.]+$/, '').replace(/_/g, ' ');
+
+            return (
+              <div key={file} className="w-28 flex-shrink-0 border rounded-xl p-2 text-center text-xs bg-white shadow">
+                <div className="mb-1 w-full h-14 rounded overflow-hidden">
+                  <Image
+                    src={`/store/${file}`}
+                    alt={name}
+                    width={122}
+                    height={56}
+                    className="object-cover w-full h-full"
+                  />
+                </div>
+                <div className="text-[#484747] font-bold text-[9px] font-inter mb-1 capitalize">{name}</div>
+                <div className="text-gray-500 mb-1">R$ 30,00</div>
+                <button className="border text-orange-500 border-orange-300 rounded px-2 py-0.5 text-[10px]">+ Adicionar</button>
               </div>
-              <div className="text-[#484747] font-bold text-[9px] font-inter mb-1">Taça</div>
-              <div className="text-gray-500 mb-1">R$ 30,00</div>
-              <button className="border text-orange-500 border-orange-300 rounded px-2 py-0.5 text-[10px]">+ Adicionar</button>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- atualiza scroll horizontal de profissionais com imagens da pasta `works`
- atualiza lista de novidades com imagens da pasta `store`
- oculta barras de navegação de ambos os scrolls e remove ícone indesejado do rodapé

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68779234d12c8330a6bf5c06faee6266