### PR TITLE
Improve professionals list scroll behavior

### DIFF
--- a/src/app/professionals/list/page.tsx
+++ b/src/app/professionals/list/page.tsx
@@ -1,11 +1,17 @@
 'use client';
 
 import Image from 'next/image';
-import { Button } from '@mui/material';
-import { useState } from 'react';
+import { Button, Rating } from '@mui/material';
+import React, { useRef, useState } from 'react';
 
 export default function ProfessionalsListPage() {
   const [area] = useState('Pintor');
+
+  const [dragging, setDragging] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const pointerDown = useRef(false);
+  const startY = useRef(0);
+  const startScroll = useRef(0);
 
   const professionals = Array.from({ length: 15 }).map((_, i) => ({
     id: i + 1,
@@ -14,14 +20,41 @@ export default function ProfessionalsListPage() {
     description: 'Especialista em pintura residencial e comercial.'
   }));
 
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    const container = scrollRef.current;
+    if (!container) return;
+    pointerDown.current = true;
+    startY.current = e.clientY;
+    startScroll.current = container.scrollTop;
+    setDragging(true);
+    container.setPointerCapture(e.pointerId);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!pointerDown.current) return;
+    const container = scrollRef.current;
+    if (!container) return;
+    const walk = e.clientY - startY.current;
+    container.scrollTop = startScroll.current - walk;
+  };
+
+  const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
+    pointerDown.current = false;
+    const container = scrollRef.current;
+    if (container) {
+      container.releasePointerCapture(e.pointerId);
+    }
+    setDragging(false);
+  };
+
   return (
-    <div className="min-h-screen bg-[#FDFDFB] px-4 py-6 space-y-6 pb-20">
+    <div className="min-h-screen bg-[#FDFDFB] px-4 py-6 space-y-6 pb-20 flex flex-col">
 
       {/* Seção 1: Título da categoria */}
       <h1 className="text-[15px] font-medium text-[#484747] font-inter">{area}</h1>
 
       {/* Seção 2: Card destaque */}
-      <div className="bg-white shadow rounded-xl p-4 flex items-center space-x-4">
+      <div className="bg-white shadow rounded-xl p-4 flex items-center space-x-4 sticky top-4 z-10">
         <div className="w-16 h-16 rounded-full overflow-hidden">
           <Image
             src="/list_workers/worker13.jpg"
@@ -33,7 +66,8 @@ export default function ProfessionalsListPage() {
         </div>
         <div className="flex-1">
           <h2 className="text-sm font-semibold text-[#484747] font-inter">Carla Dias</h2>
-          <p className="text-xs text-gray-500 font-inter mb-2">Especialista em pintura de interiores com 10 anos de experiência.</p>
+          <p className="text-xs text-gray-500 font-inter mb-1">Especialista em pintura de interiores com 10 anos de experiência.</p>
+          <Rating name="highlight-rating" value={4} readOnly size="small" className="mb-2" />
           <Button
             variant="contained"
             sx={{
@@ -45,9 +79,10 @@ export default function ProfessionalsListPage() {
               },
               '&:active': {
                 backgroundColor: '#FFA13F'
-              }
+              },
+              width: '70%'
             }}
-            fullWidth
+            className="mx-auto"
           >
             Ver perfil
           </Button>
@@ -55,7 +90,14 @@ export default function ProfessionalsListPage() {
       </div>
 
       {/* Seção 3: Lista vertical de profissionais */}
-      <div className="space-y-4">
+      <div
+        ref={scrollRef}
+        className={`space-y-4 overflow-y-auto no-scrollbar flex-1 ${dragging ? 'cursor-grabbing' : 'cursor-grab'}`}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={endDrag}
+        onPointerLeave={endDrag}
+      >
         {professionals.map((pro, i) => (
           <div key={i} className="flex items-center bg-white p-4 rounded-xl shadow">
             <div className="w-14 h-14 rounded-full overflow-hidden mr-4">
@@ -69,7 +111,8 @@ export default function ProfessionalsListPage() {
             </div>
             <div className="flex-1">
               <h3 className="text-sm font-semibold text-[#484747] font-inter">{pro.name}</h3>
-              <p className="text-xs text-gray-500 font-inter">{pro.description}</p>
+              <p className="text-xs text-gray-500 font-inter mb-1">{pro.description}</p>
+              <Rating name={`rating-${pro.id}`} value={4} readOnly size="small" className="mb-1" />
             </div>
             <Button
               variant="contained"


### PR DESCRIPTION
## Summary
- make highlighted professional sticky
- allow dragging to scroll the professionals list
- hide scrollbar and make container flex
- add star rating to highlight and list items
- adjust highlight button width

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ddbdd2cc833090209552c58df8fb