### PR TITLE
Add links to professionals list

### DIFF
--- a/src/app/professionals/list/page.tsx
+++ b/src/app/professionals/list/page.tsx
@@ -4,10 +4,12 @@
 import Image from 'next/image';
 import { Button, Rating } from '@mui/material';
 import React, { useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 
 
 export default function ProfessionalsListPage() {
-  const [area] = useState('Pintor');
+  const searchParams = useSearchParams();
+  const [area] = useState(searchParams.get('area') ?? 'Profissionais');
 
 
   const [dragging, setDragging] = useState(false);

--- a/src/app/professionals/page.tsx
+++ b/src/app/professionals/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { useRef, useState } from 'react';
 import {
   Search,
@@ -162,14 +163,18 @@ export default function ProfessionalsPage() {
       >
         <div className="flex space-x-5">
           {works.map(({ name, Icon }) => (
-            <div key={name} className="flex flex-col items-center">
+            <Link
+              key={name}
+              href={`/professionals/list?area=${encodeURIComponent(name)}`}
+              className="flex flex-col items-center"
+            >
               <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center mb-1 overflow-hidden">
                 <Icon fontSize="small" className="text-gray-600" />
               </div>
               <span className="text-[9px] text-[#6D6D6D] font-medium font-inter capitalize">
                 {name}
               </span>
-            </div>
+            </Link>
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- link each professional type to a list page
- read selected profession from query params

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a29996bdc83309b8b1ff15e14bb41