### PR TITLE
Limit card button width

### DIFF
--- a/src/app/professionals/list/page.tsx
+++ b/src/app/professionals/list/page.tsx
@@ -157,7 +157,8 @@ export default function ProfessionalsListPage() {
                     },
                     '&:active': {
                       backgroundColor: '#FFA13F'
-                    }
+                    },
+                    maxWidth: '200px'
                   }}
                 >
                   Ver perfil


### PR DESCRIPTION
## Summary
- set a maximum width of 200px for the professional cards' button on the list page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a3c714bf48330b7186ce93879a4e0