### PR TITLE
Wrap professional list with styled container

### DIFF
--- a/src/app/professionals/list/page.tsx
+++ b/src/app/professionals/list/page.tsx
@@ -114,14 +114,15 @@ export default function ProfessionalsListPage() {
 
       {/* Seção 2: Lista vertical de profissionais */}
       <div className="relative flex-1 scroll-mask">
-        <div
-          ref={scrollRef}
-          className={`space-y-4 overflow-y-auto no-scrollbar h-full ${dragging ? 'cursor-grabbing' : 'cursor-grab'}`}
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={endDrag}
-          onPointerLeave={endDrag}
-        >
+        <div className="mt-4 border border-gray-200 rounded-lg p-2">
+          <div
+            ref={scrollRef}
+            className={`space-y-4 overflow-y-auto no-scrollbar h-full ${dragging ? 'cursor-grabbing' : 'cursor-grab'}`}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={endDrag}
+            onPointerLeave={endDrag}
+          >
           {professionals.map((pro, i) => (
             <div key={i} className="flex items-center bg-white p-4 rounded-xl shadow">
               <div className="w-14 h-14 rounded-full overflow-hidden mr-4">


### PR DESCRIPTION
## Summary
- wrap professionals list in a bordered container with top margin

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a713da30c83308dda358b0c91ce94