### PR TITLE
Adiciona margem acima do link 'ver mais'

### DIFF
--- a/src/app/professionals/page.tsx
+++ b/src/app/professionals/page.tsx
@@ -228,7 +228,7 @@ export default function ProfessionalsPage() {
             );
           })}
         </div>
-        <div className="flex justify-end mt-1">
+        <div className="flex justify-end mt-2">
           <Link
             href=""
             className="text-[#484747] font-inter font-medium text-[11px] underline"


### PR DESCRIPTION
## Summary
- aumenta o espaçamento superior do link "ver mais" na seção de novidades

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba56b91708330aa226695257df100