### PR TITLE
Add footer icons to professionals list page

### DIFF
--- a/src/app/professionals/list/page.tsx
+++ b/src/app/professionals/list/page.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { Button, Rating } from '@mui/material';
 import React, { useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
+import FooterIcons from '../../components/footer_icons';
 
 
 export default function ProfessionalsListPage() {
@@ -168,6 +169,8 @@ export default function ProfessionalsListPage() {
           </div>
         ))}
       </div>
+      {/* Rodapé com ícones MUI */}
+      <FooterIcons />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- import FooterIcons in professionals list page
- display FooterIcons at the bottom of the list page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bac57849483308b8da7685ef2d5ee