### PR TITLE
Fix footer layout on professionals list

### DIFF
--- a/src/app/components/footer_icons.tsx
+++ b/src/app/components/footer_icons.tsx
@@ -4,7 +4,7 @@ import { Home, Build, SearchOutlined, ContentCut, Person } from '@mui/icons-mate
 
 export default function FooterIcons() {
   return (
-    <div className="fixed bottom-0 left-0 right-0 h-16 bg-white flex items-center justify-around shadow-md rounded-t-xl px-4">
+    <div className="fixed bottom-0 left-0 right-0 h-16 bg-white flex items-center justify-around shadow-md rounded-t-xl px-4 z-30">
       <Link href="">
         <Home className="text-gray-600" />
       </Link>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[#FDFDFB]`}
       >
         {children}
       </body>

--- a/src/app/professionals/list/page.tsx
+++ b/src/app/professionals/list/page.tsx
@@ -59,7 +59,7 @@ export default function ProfessionalsListPage() {
 
 
   return (
-    <div className="min-h-screen bg-[#FDFDFB] px-4 py-6 flex flex-col space-y-6 mt-4 mx-4">
+    <div className="min-h-screen bg-[#FDFDFB] px-4 py-6 flex flex-col space-y-6 mt-4 mx-4 pb-24">
 
 
       {/* Título e card de destaque fixos */}


### PR DESCRIPTION
## Summary
- set light background color on the `<body>` element
- ensure footer is above other content
- add bottom padding on professional list page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc41d3a888330a53488ae2c21b3b1