### PR TITLE
Remove unused button

### DIFF
--- a/src/app/professionals/list/page.tsx
+++ b/src/app/professionals/list/page.tsx
@@ -144,26 +144,6 @@ export default function ProfessionalsListPage() {
                   size="small"
                   className="mb-1"
                 />
-                <Button
-                  variant="contained"
-                  size="small"
-                  sx={{
-                    backgroundColor: '#F88208',
-                    textTransform: 'none',
-                    fontWeight: 500,
-                    fontSize: '12px',
-                    padding: '4px 12px',
-                    '&:hover': {
-                      backgroundColor: '#FFA13F'
-                    },
-                    '&:active': {
-                      backgroundColor: '#FFA13F'
-                    },
-                    maxWidth: '160px'
-                  }}
-                >
-                  Ver perfil
-                </Button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove the `Ver perfil` button from the professionals list section

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc8b36d708330b08a77cca74353a4