### PR TITLE
Remove FooterIcons from professionals page

### DIFF
--- a/src/app/professionals/page.tsx
+++ b/src/app/professionals/page.tsx
@@ -20,7 +20,6 @@ import {
   Pool,
   Handyman,
 } from '@mui/icons-material';
-import FooterIcons from '../components/footer_icons';
 
 export default function ProfessionalsPage() {
   const [search, setSearch] = useState('');
@@ -233,8 +232,6 @@ export default function ProfessionalsPage() {
           </Link>
         </div>
       </div>
-      {/* Rodapé com ícones MUI */}
-      <FooterIcons />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove the FooterIcons import and component usage from professionals page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bce321384833089b84207eedc7fc8