### PR TITLE
Add FooterIcons component to professionals page

### DIFF
--- a/src/app/professionals/page.tsx
+++ b/src/app/professionals/page.tsx
@@ -20,6 +20,7 @@ import {
   Pool,
   Handyman,
 } from '@mui/icons-material';
+import FooterIcons from '../components/footer_icons';
 
 export default function ProfessionalsPage() {
   const [search, setSearch] = useState('');
@@ -232,6 +233,8 @@ export default function ProfessionalsPage() {
           </Link>
         </div>
       </div>
+      {/* Rodapé com ícones MUI */}
+      <FooterIcons />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- import `FooterIcons` in professionals main page
- add footer component at the bottom of the page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bcfa00cb483308bac6bdf22dad89a