### PR TITLE
Add hire button on schedule page

### DIFF
--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -262,6 +262,11 @@ export default function ScheduleServicePage() {
                       onChange={(e) => setNotes(e.target.value)}
                     />
                   </div>
+                  <button
+                    className="mt-4 w-full bg-[#F88208] text-white font-medium py-2 rounded-lg hover:bg-[#FFA13F] active:bg-[#FFA13F]"
+                  >
+                    contratar
+                  </button>
                 </>
               )}
             </>


### PR DESCRIPTION
## Summary
- add orange "contratar" button under notes textarea on schedule page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894bd904c3883309fd621e524f49e4e