### PR TITLE
Inclui FooterIcons na página de agendamento

### DIFF
--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -6,6 +6,7 @@ import StarIcon from '@mui/icons-material/Star';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import FooterIcons from '../components/footer_icons';
 
 export default function ScheduleServicePage() {
   const [currentMonth, setCurrentMonth] = useState(new Date().getMonth());
@@ -277,6 +278,7 @@ export default function ScheduleServicePage() {
           <p className="text-sm text-gray-500 mt-3">Selecione um dia</p>
         )}
       </div>
+      <FooterIcons />
     </div>
   );
 }


### PR DESCRIPTION
## Resumo
- adiciona importação de FooterIcons na página de agendamento
- renderiza FooterIcons no final da página de agendamento para consistência com a lista de profissionais

## Testes
- `npm test` *(falhou: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894c6a3e73483309696d80ff27edf1f