### PR TITLE
Adicionar botão "Contratar" na página de agendamento

### DIFF
--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -262,12 +262,12 @@ export default function ScheduleServicePage() {
                     <a href="" className="mt-2 inline-block text-gray-500">
                       <CloudUploadIcon />
                     </a>
+                    <button
+                      className="mt-2 w-full bg-[#F88208] text-white font-medium py-2 rounded-lg hover:bg-[#FFA13F] active:bg-[#FFA13F]"
+                    >
+                      Contratar
+                    </button>
                   </div>
-                  <button
-                    className="mt-4 w-full bg-[#F88208] text-white font-medium py-2 rounded-lg hover:bg-[#FFA13F] active:bg-[#FFA13F]"
-                  >
-                    contratar
-                  </button>
                 </>
               )}
             </>


### PR DESCRIPTION
## Summary
- Adicionar botão laranja "Contratar" abaixo do ícone de upload na página de agendamento

## Testing
- `npm test` (erro: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894c89197f88330ae3bcbb477093ca6