### PR TITLE
feat: add orange button component

### DIFF
--- a/src/app/components/button_orange.tsx
+++ b/src/app/components/button_orange.tsx
@@ -1,0 +1,17 @@
+'use client';
+import React from 'react';
+
+interface ButtonOrangeProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+}
+
+export default function ButtonOrange({ children, className = '', ...props }: ButtonOrangeProps) {
+  return (
+    <button
+      className={`bg-[#F88208] hover:bg-[#FFA13F] active:bg-[#FFA13F] text-white font-semibold py-2 px-4 rounded ${className}`.trim()}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable orange button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894cc8719a08330b2435967d159d5b8