### PR TITLE
Reposition image upload icon

### DIFF
--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -259,10 +259,10 @@ export default function ScheduleServicePage() {
                       value={notes}
                       onChange={(e) => setNotes(e.target.value)}
                     />
-                    <a href="" className="mt-2 inline-block text-gray-500">
-                      <CloudUploadIcon />
-                    </a>
                   </div>
+                  <a href="" className="mt-2 inline-block text-gray-500">
+                    <CloudUploadIcon />
+                  </a>
                   <button
                     className="mt-2 w-full bg-[#F88208] text-white font-medium py-2 rounded-lg hover:bg-[#FFA13F] active:bg-[#FFA13F]"
                   >


### PR DESCRIPTION
## Summary
- move CloudUpload icon outside text area and place before action button on schedule page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894dbc3bac48330bfec8fe202bb66ea