### PR TITLE
fix schedule page spacing for fixed footer

### DIFF
--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -115,7 +115,7 @@ export default function ScheduleServicePage() {
   };
 
   return (
-    <div className="min-h-screen bg-[#FDFDFB] px-4 py-6 text-[#484747]">
+    <div className="min-h-screen bg-[#FDFDFB] px-4 pt-6 pb-24 text-[#484747]">
       {/* Header do profissional */}
       <div className="bg-white rounded-xl shadow-md p-4 flex items-center gap-4">
         <img


### PR DESCRIPTION
## Summary
- prevent fixed footer from covering schedule content by adding bottom padding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894e178ad788330b37c2687ff32b596