### PR TITLE
Add registration link on login page

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -62,6 +62,13 @@ export default function LoginPage() {
         </a>
       </form>
 
+      <a
+        href="#"
+        className="w-full max-w-xs text-center mt-4 text-base text-gray-600 underline"
+      >
+        Cadastre-se
+      </a>
+
       {/* Social login */}
       <div className="flex flex-col items-center gap-4 mt-10">
         <span className="text-sm text-gray-600">Ou Continue com:</span>


### PR DESCRIPTION
## Summary
- add highlighted "Cadastre-se" link between password reset and social login

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689612d95d208330bb03cb2d2ded0fa3