### PR TITLE
Atualiza página de cadastro de cliente

### DIFF
--- a/src/app/user_registration/page.tsx
+++ b/src/app/user_registration/page.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import {
   Box,
   Container,
-  Paper,
   Stack,
   TextField,
   Typography,
@@ -23,7 +22,6 @@ type FormValues = {
 
 const ORANGE_MAIN = '#F88208';
 const ORANGE_HOVER = '#FFA13F';
-const CARD_BG = '#FDFDFB';
 const FIELD_BORDER = '#FFEDCF';
 
 export default function UserRegistrationPage() {
@@ -52,29 +50,15 @@ export default function UserRegistrationPage() {
 
   return (
     <Container component="main" maxWidth="sm" sx={{ py: { xs: 3, md: 6 } }}>
-      <Box display="flex" justifyContent="center">
-        <Paper
-          elevation={4}
-          sx={{
-            width: '100%',
-            maxWidth: 375,
-            minHeight: 812,
-            p: 3,
-            borderRadius: '50px',
-            bgcolor: CARD_BG,
-            boxShadow:
-              '0px 20px 40px rgba(0,0,0,0.06), 0px 2px 8px rgba(0,0,0,0.04)',
-          }}
-        >
-          <Typography
-            variant="subtitle1"
-            sx={{ fontWeight: 600, color: '#484747', mb: 2 }}
-          >
-            user registration
-          </Typography>
+      <Typography
+        variant="subtitle1"
+        sx={{ fontWeight: 600, color: '#484747', mb: 2 }}
+      >
+        Cadastro de Cliente
+      </Typography>
 
-          <Box component="form" noValidate onSubmit={handleSubmit(onSubmit)}>
-            <Stack spacing={2.5}>
+      <Box component="form" noValidate onSubmit={handleSubmit(onSubmit)}>
+        <Stack spacing={2.5}>
               <LabeledField label="Nome Completo *">
                 <Controller
                   name="fullName"
@@ -219,8 +203,6 @@ export default function UserRegistrationPage() {
               </Button>
             </Stack>
           </Box>
-        </Paper>
-      </Box>
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
- Renomeia título para "Cadastro de Cliente"
- Remove o card com cantos arredondados ao redor do formulário

## Testing
- `npm test` (faltando script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896347596ac8330b38da7eeb3c2b9c4