### PR TITLE
Show professionals list on search icon click

### DIFF
--- a/src/app/search_professionals/page.tsx
+++ b/src/app/search_professionals/page.tsx
@@ -204,6 +204,11 @@ function ListCard({ pro }: { pro: Professional }) {
 export default function SearchProfessionalsPage() {
   const featured = professionals.find((p) => p.featured);
   const rest = professionals.filter((p) => !p.featured);
+  const [showList, setShowList] = React.useState(false);
+
+  const handleSearchClick = () => {
+    setShowList(true);
+  };
 
   return (
     <Container
@@ -233,7 +238,13 @@ export default function SearchProfessionalsPage() {
             placeholder="Pintor"
             className="flex-grow bg-transparent outline-none text-sm font-inter"
           />
-          <SearchRoundedIcon className="text-gray-500" fontSize="small" />
+          <button
+            type="button"
+            onClick={handleSearchClick}
+            className="text-gray-500 bg-transparent border-none"
+          >
+            <SearchRoundedIcon fontSize="small" />
+          </button>
         </div>
       </div>
 
@@ -241,11 +252,13 @@ export default function SearchProfessionalsPage() {
       {featured && <FeaturedCard pro={featured} />}
 
       {/* Lista */}
-      <Stack spacing={1.5} sx={{ mt: 0.5 }}>
-        {rest.map((pro) => (
-          <ListCard key={pro.id} pro={pro} />)
-        )}
-      </Stack>
+      {showList && (
+        <Stack spacing={1.5} sx={{ mt: 0.5 }}>
+          {rest.map((pro) => (
+            <ListCard key={pro.id} pro={pro} />
+          ))}
+        </Stack>
+      )}
 
       <Box sx={{ flexGrow: 1 }} />
 


### PR DESCRIPTION
## Summary
- reveal professional list only after clicking the search icon on search professionals page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a3f00d21883309c487a872987fccd