### PR TITLE
Replace download icon with save image button

### DIFF
--- a/src/app/ai_personalization/page.tsx
+++ b/src/app/ai_personalization/page.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { ChevronRight } from '@mui/icons-material';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
-import DownloadIcon from '@mui/icons-material/Download';
 import FooterIcons from '@/app/components/footer_icons';
 import { useState } from 'react';
 
@@ -79,9 +78,9 @@ export default function AiPersonalizationPage() {
               />
             </div>
             <div className="mt-2">
-              <Link href="#">
-                <DownloadIcon className="text-[#484747]" />
-              </Link>
+              <button className="bg-[#F88208] hover:bg-[#FFA13F] active:bg-[#FFA13F] text-white font-semibold py-2 px-4 rounded-lg shadow-md text-sm">
+                salvar imagem
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- swap download icon for orange `salvar imagem` button on AI personalization page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a51b887e0833091efb5db14aac2a1