### PR TITLE
Add spacing after save image button on AI personalization page

### DIFF
--- a/src/app/ai_personalization/page.tsx
+++ b/src/app/ai_personalization/page.tsx
@@ -78,7 +78,7 @@ export default function AiPersonalizationPage() {
               />
             </div>
             <div className="mt-2">
-              <button className="bg-[#F88208] hover:bg-[#FFA13F] active:bg-[#FFA13F] text-white font-semibold py-2 px-4 rounded-lg shadow-md text-sm">
+              <button className="bg-[#F88208] hover:bg-[#FFA13F] active:bg-[#FFA13F] text-white font-semibold py-2 px-4 rounded-lg shadow-md text-sm mb-5">
                 salvar imagem
               </button>
             </div>


### PR DESCRIPTION
## Summary
- add 20px bottom margin after the "salvar imagem" button on AI personalization page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a59e93bac8330bfeaf272838190ef