### PR TITLE
style: align save image button to right

### DIFF
--- a/src/app/ai_personalization/page.tsx
+++ b/src/app/ai_personalization/page.tsx
@@ -77,7 +77,7 @@ export default function AiPersonalizationPage() {
                 className="w-full object-cover"
               />
             </div>
-            <div className="mt-2">
+            <div className="mt-2 flex justify-end">
               <button className="bg-[#F88208] hover:bg-[#FFA13F] active:bg-[#FFA13F] text-white font-semibold py-2 px-4 rounded-lg shadow-md text-sm mb-5">
                 salvar imagem
               </button>


### PR DESCRIPTION
## Summary
- align "salvar imagem" button to the right on AI personalization page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a5b22bd008330b9546137a698de4d