### PR TITLE
Link footer icons to respective pages

### DIFF
--- a/src/app/components/footer_icons/page.tsx
+++ b/src/app/components/footer_icons/page.tsx
@@ -5,19 +5,19 @@ import { Home, PhotoFilter, SearchOutlined, Build, Person } from '@mui/icons-mat
 export default function FooterIcons() {
   return (
     <div className="fixed bottom-0 left-0 right-0 h-16 bg-white flex items-center justify-around shadow-md rounded-t-xl px-4 z-30">
-      <Link href="">
+      <Link href="/professionals">
         <Home className="text-gray-600" />
       </Link>
-      <Link href="">
+      <Link href="/ai_personalization">
         <PhotoFilter className="text-gray-600" />
       </Link>
-      <Link href="">
+      <Link href="/search_professionals">
         <SearchOutlined className="text-gray-600" />
       </Link>
-      <Link href="">
+      <Link href="/worker_registration">
         <Build className="text-gray-600" />
       </Link>
-      <Link href="">
+      <Link href="" onClick={(e) => e.preventDefault()}>
         <Person className="text-gray-600" />
       </Link>
     </div>


### PR DESCRIPTION
## Summary
- connect footer icons to professionals, AI personalization, search, and worker registration pages
- keep profile icon disabled with no navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a5efd8fe08330a955f9ba899c36be