### PR TITLE
Move image upload icon outside schedule dialog

### DIFF
--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -259,15 +259,15 @@ export default function ScheduleServicePage() {
                       value={notes}
                       onChange={(e) => setNotes(e.target.value)}
                     />
-                    <a href="" className="mt-2 inline-block text-gray-500">
-                      <CloudUploadIcon />
-                    </a>
                     <button
                       className="mt-2 w-full bg-[#F88208] text-white font-medium py-2 rounded-lg hover:bg-[#FFA13F] active:bg-[#FFA13F]"
                     >
                       Contratar
                     </button>
                   </div>
+                  <a href="" className="mt-2 inline-block text-gray-500">
+                    <CloudUploadIcon />
+                  </a>
                 </>
               )}
             </>


### PR DESCRIPTION
## Summary
- place image upload icon below the notes dialog instead of inside it

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a611f11248330bceec8fbd44bf44c