### PR TITLE
Add footer icons to user registration page

### DIFF
--- a/src/app/user_registration/page.tsx
+++ b/src/app/user_registration/page.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import { Controller, useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';  // Import do useRouter
+import FooterIcons from '../components/footer_icons/page';
 
 type FormValues = {
   fullName: string;
@@ -56,11 +57,12 @@ export default function UserRegistrationPage() {
   };
 
   return (
-    <Container
-      component="main"
-      maxWidth="sm"
-      sx={{ py: { xs: 3, md: 6 }, bgcolor: BACKGROUND_COLOR, minHeight: '100vh' }}
-    >
+    <>
+      <Container
+        component="main"
+        maxWidth="sm"
+        sx={{ py: { xs: 3, md: 6 }, bgcolor: BACKGROUND_COLOR, minHeight: '100vh' }}
+      >
       <Typography
         variant="subtitle1"
         sx={{ fontWeight: 600, color: '#484747', mb: 2 }}
@@ -214,7 +216,9 @@ export default function UserRegistrationPage() {
           </Button>
         </Stack>
       </Box>
-    </Container>
+      </Container>
+      <FooterIcons />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- Render navigation footer on user registration page using existing FooterIcons component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a64b1c3d48330b8a377647cf63e78