### PR TITLE
Link footer profile icon to registration page

### DIFF
--- a/src/app/components/footer_icons/page.tsx
+++ b/src/app/components/footer_icons/page.tsx
@@ -17,7 +17,7 @@ export default function FooterIcons() {
       <Link href="/worker_registration">
         <Build className="text-gray-600" />
       </Link>
-      <Link href="" onClick={(e) => e.preventDefault()}>
+      <Link href="/registration">
         <Person className="text-gray-600" />
       </Link>
     </div>


### PR DESCRIPTION
## Summary
- Link the profile icon in the footer to the registration flow.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b64758d1083309c282a203ac02b8d