### PR TITLE
Reduzir altura dos campos de texto na tela de cadastro

### DIFF
--- a/src/app/user_registration/page.tsx
+++ b/src/app/user_registration/page.tsx
@@ -245,14 +245,17 @@ function StyledTextField(props: React.ComponentProps<typeof TextField>) {
   return (
     <TextField
       fullWidth
-      size="medium"
       variant="outlined"
       InputLabelProps={{ shrink: false }}
       {...props}
       sx={{
         '& .MuiOutlinedInput-root': {
+          height: '39.2px',
           borderRadius: '12px',
           bgcolor: '#FFFFFF',
+          '& .MuiOutlinedInput-input': {
+            padding: '8px 14px',
+          },
           '& input::placeholder': { color: '#A4A4A4', opacity: 1 },
           '& fieldset': {
             borderColor: FIELD_BORDER,


### PR DESCRIPTION
## Summary
- shrink user registration text field height by 30%

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b6605770c8330aa5eb8243fd6cee6