### PR TITLE
Adjust spacing in worker registration page

### DIFF
--- a/src/app/worker_registration/page.tsx
+++ b/src/app/worker_registration/page.tsx
@@ -239,7 +239,8 @@ export default function WorkerRegistrationPage() {
             disabled={isSubmitting}
             sx={{
               alignSelf: 'flex-start',
-              mt: 0,
+              mt: '-10px',
+              mb: '50px',
               px: 4,
               py: 1.2,
               borderRadius: '12px',


### PR DESCRIPTION
## Summary
- reduce gap before submit button on worker registration form
- add 50px space after submit button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bab5e5f548330b0e010a1b32a2ecd