### PR TITLE
Ensure worker registration submit button stays above footer

### DIFF
--- a/src/app/worker_registration/page.tsx
+++ b/src/app/worker_registration/page.tsx
@@ -240,7 +240,7 @@ export default function WorkerRegistrationPage() {
             sx={{
               alignSelf: 'flex-start',
               mt: '-10px',
-              mb: '50px',
+              mb: '100px',
               px: 4,
               py: 1.2,
               borderRadius: '12px',


### PR DESCRIPTION
## Summary
- increase bottom margin on worker registration submit button so it isn't covered by footer icons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689baefcdb8c833082e4ade11d45e7f4