### PR TITLE
Fix worker registration submit button overlap

### DIFF
--- a/src/app/worker_registration/page.tsx
+++ b/src/app/worker_registration/page.tsx
@@ -78,7 +78,12 @@ export default function WorkerRegistrationPage() {
       <Container
         component="main"
         maxWidth="sm"
-        sx={{ py: { xs: 3, md: 6 }, bgcolor: BACKGROUND_COLOR, minHeight: '100vh' }}
+        sx={{
+          py: { xs: 3, md: 6 },
+          pb: 10,
+          bgcolor: BACKGROUND_COLOR,
+          minHeight: '100vh',
+        }}
       >
         <Typography
           variant="subtitle1"
@@ -239,8 +244,7 @@ export default function WorkerRegistrationPage() {
             disabled={isSubmitting}
             sx={{
               alignSelf: 'flex-start',
-              mt: '-10px',
-              mb: '100px',
+              mt: 1,
               px: 4,
               py: 1.2,
               borderRadius: '12px',


### PR DESCRIPTION
## Summary
- add bottom padding so worker registration button sits above footer icons
- streamline button spacing to prevent overlap

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bb0f8a0488330b7ee13329e6e9a53